### PR TITLE
adding aes ccm psa_crypto support

### DIFF
--- a/crypto.c
+++ b/crypto.c
@@ -557,7 +557,9 @@ dtls_ecdsa_verify_sig(const unsigned char *pub_key_x,
 				    sizeof(sha256hash), result_r, result_s);
 }
 #endif /* DTLS_ECC */
-
+#ifdef USE_PSA
+#include "platform-specific/dtls_aes_ccm_psa.c"
+#else /* USE_PSA */
 int
 dtls_encrypt_params(const dtls_ccm_params_t *params,
                     const unsigned char *src, size_t length,
@@ -583,20 +585,6 @@ dtls_encrypt_params(const dtls_ccm_params_t *params,
 error:
   dtls_cipher_context_release();
   return ret;
-}
-
-int 
-dtls_encrypt(const unsigned char *src, size_t length,
-	     unsigned char *buf,
-	     const unsigned char *nonce,
-	     const unsigned char *key, size_t keylen,
-	     const unsigned char *aad, size_t la)
-{
-  /* For backwards-compatibility, dtls_encrypt_params is called with
-   * M=8 and L=3. */
-  const dtls_ccm_params_t params = { nonce, 8, 3 };
-
-  return dtls_encrypt_params(&params, src, length, buf, key, keylen, aad, la);
 }
 
 int
@@ -625,6 +613,21 @@ dtls_decrypt_params(const dtls_ccm_params_t *params,
 error:
   dtls_cipher_context_release();
   return ret;
+}
+#endif /* USE_PSA */
+
+int 
+dtls_encrypt(const unsigned char *src, size_t length,
+	     unsigned char *buf,
+	     const unsigned char *nonce,
+	     const unsigned char *key, size_t keylen,
+	     const unsigned char *aad, size_t la)
+{
+  /* For backwards-compatibility, dtls_encrypt_params is called with
+   * M=8 and L=3. */
+  const dtls_ccm_params_t params = { nonce, 8, 3 };
+
+  return dtls_encrypt_params(&params, src, length, buf, key, keylen, aad, la);
 }
 
 int

--- a/dtls.c
+++ b/dtls.c
@@ -46,6 +46,10 @@
 #include "uthash.h"
 #endif /* DTLS_PEERS_NOHASH */
 
+#ifdef USE_PSA
+#include "psa/crypto.h"
+#endif
+
 #include "dtls_debug.h"
 #include "numeric.h"
 #include "netq.h"
@@ -327,6 +331,9 @@ free_context(dtls_context_t *context) {
 
 void
 dtls_init(void) {
+#ifdef USE_PSA
+  psa_crypto_init();
+#endif /* USE_PSA */
   dtls_clock_init();
   crypto_init();
   netq_init();

--- a/platform-specific/dtls_aes_ccm_psa.c
+++ b/platform-specific/dtls_aes_ccm_psa.c
@@ -1,0 +1,92 @@
+
+/*******************************************************************************
+ *
+ * Copyright (c) 2011-2025 Lukas Luger (TUD) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Lukas Luger    - adding psa crypto support
+ *
+ *******************************************************************************/
+#include "crypto.h"
+#include "psa/crypto.h"
+
+int
+dtls_encrypt_params(const dtls_ccm_params_t *params,
+                    const unsigned char *src, size_t length,
+                    unsigned char *buf,
+                    const unsigned char *key, size_t keylen,
+                    const unsigned char *aad, size_t la)
+{
+  size_t actual_len;
+
+  psa_key_attributes_t attr = psa_key_attributes_init();
+  psa_key_id_t key_id = 0;
+
+  psa_key_usage_t usage = PSA_KEY_USAGE_ENCRYPT;
+  psa_set_key_usage_flags(&attr, usage);
+
+  psa_algorithm_t algo = PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, params->tag_length);
+  psa_set_key_algorithm(&attr, algo);
+
+  psa_key_type_t type = PSA_KEY_TYPE_AES;
+  psa_set_key_type(&attr, type);
+
+  psa_set_key_bits(&attr, keylen * 8);
+
+  psa_import_key(&attr, key, keylen, &key_id);
+
+  psa_status_t status = psa_aead_encrypt(key_id, algo, params->nonce, 15 - params->l, aad, la,
+                                         src, length, buf, length + params->tag_length, &actual_len);
+  
+  psa_destroy_key(key_id);
+
+  if (status == PSA_SUCCESS) {
+    return (int) actual_len;
+  }
+
+  return -1;
+}
+
+int
+dtls_decrypt_params(const dtls_ccm_params_t *params,
+                    const unsigned char *src, size_t length,
+                    unsigned char *buf,
+                    const unsigned char *key, size_t keylen,
+                    const unsigned char *aad, size_t la)
+{
+  size_t actual_len;
+
+  psa_key_attributes_t attr = psa_key_attributes_init();
+  psa_key_id_t key_id = 0;
+
+  psa_key_usage_t usage = PSA_KEY_USAGE_DECRYPT;
+  psa_set_key_usage_flags(&attr, usage);
+
+  psa_algorithm_t algo = PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, params->tag_length);
+  psa_set_key_algorithm(&attr, algo);
+
+  psa_key_type_t type = PSA_KEY_TYPE_AES;
+  psa_set_key_type(&attr, type);
+
+  psa_set_key_bits(&attr, keylen * 8);
+
+  psa_import_key(&attr, key, keylen, &key_id);
+
+  psa_status_t status = psa_aead_decrypt(key_id, algo, params->nonce, 15 - params->l, aad, la,
+                                         src, length, buf, length - params->tag_length, &actual_len);
+
+  psa_destroy_key(key_id);
+  
+  if (status == PSA_SUCCESS) {
+    return (int) actual_len;
+  }
+
+  return -1;
+}


### PR DESCRIPTION
This will be the final PR for adding PSA Certified API support to tinydtls. This time glue code for AES 128 CCM is provided.