### PR TITLE
Fix MSVC compilation (CMake-based)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ target_sources(tinydtls PRIVATE
 target_include_directories(tinydtls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_definitions(tinydtls PUBLIC DTLSv12 WITH_SHA256 SHA2_USE_INTTYPES_H DTLS_CHECK_CONTENTTYPE)
 
-if(CMAKE_GENERATOR MATCHES "Visual Studio")
+if(MSVC)
     option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)
     target_compile_options(tinydtls PRIVATE -Wall)
     if(${WARNING_TO_ERROR})


### PR DESCRIPTION
Using the Ninja generator with the MSVC compiler leads to errors due to incorrect compiler call options. In CMake, the generator and the compiler are different entities.

This fix replaces the incorrect CMake variable with the correct one that describes the current MSVC-compatible compiler.
