### PR TITLE
Update cmake min version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(tinydtls)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(tinydtls)
+project(tinydtls LANGUAGES C )
 
 include (AutoConf.cmake)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(tinydtls-tests)
+project(tinydtls-tests  LANGUAGES C )
 
 add_executable(dtls-server dtls-server.c dtls_ciphers_util.c)
 target_link_libraries(dtls-server LINK_PUBLIC tinydtls)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(tinydtls-tests)
 


### PR DESCRIPTION
Some features of cmake before 3.10 will not be longer supported by cmake.